### PR TITLE
#40 [공통] 화면 이동을 위한 StackNavigator

### DIFF
--- a/app/components/cmn/DrawerNavigator.js
+++ b/app/components/cmn/DrawerNavigator.js
@@ -1,14 +1,13 @@
 import React from "react";
 import "react-native-gesture-handler";
-import { Layout, Text, Button } from "@ui-kitten/components";
-import { NavigationContainer, DrawerActions } from "@react-navigation/native";
+import { DrawerActions } from "@react-navigation/native";
 import {
   createDrawerNavigator,
   DrawerContentScrollView,
   DrawerItemList,
   DrawerItem,
 } from "@react-navigation/drawer";
-import TrainerInfo from "../pt/TrainerInfo";
+import * as StackNavigator from "./StackNavigator";
 import Home from "../Home";
 import ExcerGuideList from "../../containers/ExcerGuideList";
 import CreateUser from "../../containers/user/CreateUser";
@@ -39,7 +38,7 @@ export default function DrawerNavigator() {
       <Drawer.Screen name="Login" component={Login} />
       <Drawer.Screen name="Home" component={Home} />
       <Drawer.Screen name="ExcerGuideList" component={ExcerGuideList} />
-      <Drawer.Screen name="TrainerInfo" component={TrainerInfo} />
+      <Drawer.Screen name="TrainerInfo" component={StackNavigator.PtStack} />
       <Drawer.Screen name="CreateUser" component={CreateUser} />
       <Drawer.Screen name="Locker" component={LockerContainer} />
     </Drawer.Navigator>

--- a/app/components/cmn/StackNavigator.js
+++ b/app/components/cmn/StackNavigator.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { createStackNavigator } from "@react-navigation/stack";
+import TrainerInfo from "../pt/TrainerInfo";
+import OT from "../pt/OT";
+
+const Stack = createStackNavigator();
+
+export const PtStack = () => {
+  return (
+    <Stack.Navigator>
+        <Stack.Screen name="TrainerInfo" component={TrainerInfo} options={{ headerShown: false }}/>
+        <Stack.Screen name="OT" component={OT} options={{ headerShown: false }}/>
+    </Stack.Navigator>
+  );
+}

--- a/app/components/pt/OT.js
+++ b/app/components/pt/OT.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function OT ({ route }) {
+    const trainerId = route.params.trainerId;
+    return (
+        <View>
+            <Text>트레이너 {trainerId}의 OT 스케줄입니다.</Text>
+        </View>
+    )
+}

--- a/app/components/pt/TrainerInfo.js
+++ b/app/components/pt/TrainerInfo.js
@@ -4,7 +4,7 @@ import { StyleSheet, View, Image, ScrollView } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 import * as actions from '../../store/actions/index'
 
-export default function TrainerInfo (props) {
+export default function TrainerInfo ({ navigation }) {
     const dispatch = useDispatch();
     const trainers = useSelector((state) => state.pt.trainers);
 
@@ -26,6 +26,11 @@ export default function TrainerInfo (props) {
     });
     
     const html = trainers.map((trainer) => {
+        
+        const handleClick = () => {
+            navigation.navigate('OT', {trainerId: trainer.id})
+        };
+
         const cardHeader = (evaProps) => (
             <Layout {...evaProps} style={styles.cardHeader}>
             <Text category='h6'>{trainer.name}</Text>
@@ -35,7 +40,7 @@ export default function TrainerInfo (props) {
     
         const cardFooter = (evaProps) => (
             <Layout {...evaProps}>
-                <Button onGetOtSchedule={()=>dispatch(actions.getOtSchedule(trainer.name))}>
+                <Button onPress={handleClick}>
                     {evaProps => <Text {...evaProps} style={[evaProps.style]}>OT예약</Text>}
                 </Button>
             </Layout>

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react-native-web": "~0.13.12",
     "react-navigation": "^4.4.1",
     "react-redux": "7.2.1",
-    "redux": "4.0.5"
+    "redux": "4.0.5",
+    "@react-navigation/stack": "5.9.1"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",


### PR DESCRIPTION
- stackNavigator.js 추가
- DrawerNavigator에서 stackNavigator를 component에 추가하여 화면이동을 할 수 있도록 개선

DrawerNavigator에 새로 메뉴를 추가하지 않고 화면을 이동할 수 있도록 네비게이터를 중첩하여 사용하도록 해보았습니다.

일단 원하는 대로 동작은 하는데 이 방법이 맞는지는 잘 모르겠네여ㅠㅠ... 
아무리 검색질을 해도 딱히 뭐가 가장 표준적인 방법인지 모르겠어서 일단 되는 대로 해 봤어용

[https://reactnavigation.org/docs/nesting-navigators](https://reactnavigation.org/docs/nesting-navigators )
여기 예제가 있으니 참고하시면 좋을 것 같습니다

[동작확인방법]
trainerInfo 메뉴 -> 아무거나 OT예약 버튼 클릭 -> OT스케줄 화면으로 이동하는지 확인

[사용방법]
stackNavigator.js에 사용할 네비게이터를 만드시고 
(stack은 가장 위에 등록된 screen이 첫 화면으로 나오니까 drawer에서 클릭했을 때 가장 먼저 나와야 할 화면을 위에 써 주세여)
drawerNavigator.js에서 component={}부분에 stackNavigator에서 자신이 만든 네비게이터를 적어주시면 됩니당
